### PR TITLE
WSL2で"but it is not a shared mount."エラーが発生する現象に対応した

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -50,7 +50,7 @@ services:
       - postgres
       - plt
     volumes:
-      - ./:/var/www/jvn/
+      - ./:/var/www/jvn
     stdin_open: true
     privileged: true
     environment:


### PR DESCRIPTION
https://kawadev.net/docker-error-shared-mount/